### PR TITLE
Fix Scala type of parameters examples

### DIFF
--- a/src/parser/scala-parser.coffee
+++ b/src/parser/scala-parser.coffee
@@ -184,13 +184,13 @@ jsParser = module.exports =
         {
           key: "tracespace", display: "Followed by space",
           code: """
-                def add(a:Int, b:Int) = a + b
+                def add(a: Int, b: Int) = a + b
                 """
         }
         {
           key: "bothspace", display: "Using space in before/after",
           code: """
-                def add(a:Int, b:Int) = a + b
+                def add(a : Int, b : Int) = a + b
                 """
         }
         {


### PR DESCRIPTION
All 3 code examples were the same, I'm guessing this was how they were supposed to be?
