### PR TITLE
two typos

### DIFF
--- a/src/parser/java-parser.coffee
+++ b/src/parser/java-parser.coffee
@@ -288,7 +288,7 @@ javaParser = module.exports =
   staticvar: (line, convention, commitUrl) ->
     convention = {lang: this.lang} unless convention
     (convention.staticvar =
-      title: "Use special prefix fot staticvar"
+      title: "Use special prefix for staticvar"
       column: [
         {
           key: "prefix", display: "Special prefix",


### PR DESCRIPTION
nospace had a space and "fot" -> "for"
